### PR TITLE
Remove manual approval step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,18 +129,11 @@ workflows:
                     - build-deploy-staging
                   filters:
                     branches:
-                      only: master                    
-            - permit-deploy-production:
-                  type: approval
-                  requires:
-                    - assume-role-production 
-                  filters:
-                    branches:
-                      only: master                    
+                      only: master                                     
             - build-deploy-production:
                   stage: "production"
                   requires:
-                      - permit-deploy-production
+                      - assume-role-production
                   filters:
                     branches:
                       only: master                      


### PR DESCRIPTION
Removing manual approval step so any changes to the config files in the "production" folder can go directly to our S3 prod folder.